### PR TITLE
Fix handling of global

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -9,7 +9,6 @@ const INTERFACES = {
 const DEFAULT_TIMEOUT_INTERVAL = 60000
 
 let adapter = {}
-let global = global
 
 /**
  * Jasmine 2.x runner


### PR DESCRIPTION
Since you are writing 
```
let global
```
the `global` value in this scope becomes undefined. See little example
```
"use strict";
var global = global;
console.log(typeof global);
```
it prints `undefined` to the console.

`var` or `let` doesn't make sense, it will not work anyway