### PR TITLE
do not rewire process object

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,5 +1,3 @@
-const process = process
-
 class JasmineReporter {
     constructor (cid, capabilities) {
         this._cid = cid

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -9,8 +9,6 @@ let reporter
 
 describe('jasmine reporter', () => {
     before(() => {
-        JasmineReporter.__Rewire__('process', { send })
-
         reporter = new JasmineReporter()
         send = reporter.send = sinon.spy()
     })
@@ -90,9 +88,5 @@ describe('jasmine reporter', () => {
         it('should have right fail count at the end', () => {
             reporter.getFailedCount().should.be.exactly(2)
         })
-    })
-
-    after(() => {
-        JasmineReporter.__ResetDependency__('process')
     })
 })


### PR DESCRIPTION
Hello! I keep trying to work with latest version webdriver.io and jasmine.

Now I found that reporter doesn't run and fails with error:  `TypeError: Cannot read property 'send' of undefined`

It is the similar error that was in #1. 

Rewiring of the `process` doesn't need because you are already overriding entire `reporter.send` method.