### PR TITLE
Fix expectationResult wrapper to use call-time 'this'

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -191,7 +191,7 @@ class JasmineAdapter {
 
     expectationResultHandler (origHandler) {
         let { expectationResultHandler } = this.config.jasmineNodeOpts
-        return (passed, data) => {
+        return function (passed, data) {
             try {
                 expectationResultHandler.call(global.browser, passed, data)
             } catch (e) {


### PR DESCRIPTION
This small patch fixes a bug using the wrong 'this' in the jasmine adapter's expectation result wrapper:

TypeError: this.expectationResultFactory is not a function
    at JasmineAdapter.Spec.addExpectationResult (C:\Users\pasquire.AUTH\Code\Optimost\jscommon\webdriver\node_modules\jasmine-core\lib\jasmine-core\jasmine.js:325:34)
    at Spec.addExpectationResult (C:\Users\pasquire.AUTH\Code\Optimost\jscommon\webdriver\node_modules\wdio-jasmine-framework\build\adapter.js:408:36)
    at Expectation.addExpectationResult (C:\Users\pasquire.AUTH\Code\Optimost\jscommon\webdriver\node_modules\jasmine-core\lib\jasmine-core\jasmine.js:534:21)
    at Expectation.toBe (C:\Users\pasquire.AUTH\Code\Optimost\jscommon\webdriver\node_modules\jasmine-core\lib\jasmine-core\jasmine.js:1407:12)
    at Object.<anonymous> (C:\Users\pasquire.AUTH\Code\Optimost\jscommon\webdriver\src\specs\loginSpec.js:8:47)
    at C:\Users\pasquire.AUTH\Code\Optimost\jscommon\webdriver\node_modules\wdio-sync\build\index.js:579:24