### PR TITLE
Failing test to capture problem with it blocks not resolving promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "jasmine": "~2.3.2",
     "babel-runtime": "^5.8.25",
-    "wdio-sync": "0.5.1"
+    "wdio-sync": "0.5.3"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/test/fixtures/hook.failure.spec.js
+++ b/test/fixtures/hook.failure.spec.js
@@ -1,0 +1,9 @@
+describe('sample test', () => {
+    beforeAll('will cause all tests to fail', () => {
+        throw new Error('causes all tests to fail')
+    })
+
+    it('fails due to exception in beforeAll', () => {
+        expect(true).toBe(true)
+    })
+})

--- a/test/fixtures/tests.async.failures.spec.js
+++ b/test/fixtures/tests.async.failures.spec.js
@@ -1,0 +1,12 @@
+global.______wdio = {}
+
+describe('sample test', () => {
+    it('promise is resolved', () => {
+        return new Promise(result => {
+            throw new Error('fail test')
+        })
+    })
+    it('fails on exception', () => {
+        throw new Error('fail test')
+    })
+})

--- a/test/fixtures/tests.async.promise.spec.js
+++ b/test/fixtures/tests.async.promise.spec.js
@@ -1,0 +1,11 @@
+global.______wdio = {}
+
+describe('sample test', () => {
+    it('foo', () => {
+        const start = new Date().getTime()
+        return browser.command().then((result) => {
+            expect(result).toBe('foo')
+            global.______wdio.it = new Date().getTime() - start
+        })
+    })
+})

--- a/test/hooks.spec.js
+++ b/test/hooks.spec.js
@@ -11,6 +11,7 @@ const specs2 = [__dirname + '/fixtures/sample2.spec.js']
 const specs3 = [__dirname + '/fixtures/sample3.spec.js']
 const specs4 = [__dirname + '/fixtures/sample4.spec.js']
 const specs5 = [__dirname + '/fixtures/sample5.spec.js']
+const failureSpec = [__dirname + '/fixtures/hook.failure.spec.js']
 const NOOP = () => {}
 
 const WebdriverIO = class {}
@@ -627,6 +628,17 @@ describe('jasmine adapter hook tests', () => {
                 let duration = afterHook.end - afterHook.start
                 duration.should.be.greaterThan(490)
             })
+        })
+    })
+
+    describe('hook exceptions', () => {
+        it('should fail test', async () => {
+            global.browser = new WebdriverIO()
+            global.browser.options = { sync: false }
+            const adapter = new JasmineAdapter(0, {}, failureSpec, {})
+            const result = await adapter.run()
+            result.should.be.equal(1, 'test should fail')
+            adapter.reporter.getFailedCount().should.be.equal(1, 'test should fail')
         })
     })
 

--- a/test/tests.spec.js
+++ b/test/tests.spec.js
@@ -2,6 +2,8 @@ import { JasmineAdapter } from '../lib/adapter'
 
 const syncSpecs = [__dirname + '/fixtures/tests.sync.spec.js']
 const asyncSpecs = [__dirname + '/fixtures/tests.async.spec.js']
+const asyncPromiseSpecs = [__dirname + '/fixtures/tests.async.promise.spec.js']
+const asyncFailureSpecs = [__dirname + '/fixtures/tests.async.failures.spec.js']
 const syncAsyncSpecs = [__dirname + '/fixtures/tests.sync.async.spec.js']
 const fdescribeSpecs = [__dirname + '/fixtures/tests.fdescribe.spec.js']
 const fitSpecs = [__dirname + '/fixtures/tests.fit.spec.js']
@@ -83,6 +85,30 @@ describe('JasmineAdapter', () => {
 
         it('should run async commands in afterEach blocks', () => {
             global.______wdio.afterEach.should.be.greaterThan(499)
+        })
+    })
+
+    describe('executes specs asynchronous promise resolution', () => {
+        before(async () => {
+            global.browser = new WebdriverIO()
+            global.browser.options = { sync: false }
+            const adapter = new JasmineAdapter(0, {}, asyncPromiseSpecs, {});
+            (await adapter.run()).should.be.equal(0, 'actual test failed')
+        })
+
+        it('should run async commands in it blocks', () => {
+            global.______wdio.it.should.be.greaterThan(499)
+        })
+    })
+
+    describe('executes specs asynchronous with failures', () => {
+        it('should capture failures', async () => {
+            global.browser = new WebdriverIO()
+            global.browser.options = { sync: false }
+            const adapter = new JasmineAdapter(0, {}, asyncFailureSpecs, {})
+            const result = await adapter.run()
+            result.should.be.equal(2, 'both tests should fail')
+            adapter.reporter.getFailedCount().should.be.equal(2, 'both tests should fail')
         })
     })
 


### PR DESCRIPTION
Here is a failing test for issue https://github.com/webdriverio/wdio-jasmine-framework/issues/13.

I figured out why your test was passing and mine was not.  

Promises returned by the `it` block are not being waited on, but because you have an `afterEach` block that also waits the promise has sufficient time to resolve before the test is completed.  

The key difference I think is that in jasmine a function is executed in async mode only when the provided function has argument length 1. If the function provided takes no arguments, jasmine assumes the test is synchronous does not provide a done function and thus does not wait for it to be called.

This is the only occurrence in `wdio-sync` where `origFn` is called using a function with 0 arguments and thus explains why there is different behavior for `it/fit` blocks then `before/after`* blocks.

https://github.com/webdriverio/wdio-sync/blob/master/index.js#L476

I can reproduce the failure in the `wdio-jasmine-framework` tests by simply making the timeout for the `it` block longer than the timeout for the `afterEach` block.