### PR TITLE
Cause jasmine framework to broadcast suite and test start and end events to the runner process

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -56,6 +56,7 @@ class JasmineReporter {
     }
 
     send (...args) {
+        process.emit(args[0].event, args)
         process.send.apply(process, args)
     }
 


### PR DESCRIPTION
I am working on a new [reporter](https://github.com/object88/wdio-coherent-reporter), which will output messages on a per-suite basis.  This will reduce confusion between messages coming from different runners, which are typically and frequently intertwined.

One of the key features is the ability to emit a message from a suite (from a logging class, for example), and have it reported inline with the test or setup that it gets invoked from.  For this to work, however, the logger needs to know what the current suite and test is.  The existing wdio-jasmine-framework shares this information, but only with reporters, which are running on the originating process.

This PR will broadcast `[suite|test]:[start|end]` to the currently running process as well.
