### PR TITLE
Wdio spec reporter issues 11

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -10,8 +10,12 @@ class JasmineReporter {
     suiteStarted (suite = {}) {
         this._suiteStart = new Date()
         suite.type = 'suite'
+
         this.emit('suite:start', suite)
-        this._parent.push(suite.description)
+        this._parent.push({
+            description: suite.description,
+            id: suite.id
+        })
     }
 
     specStarted (test = {}) {
@@ -52,10 +56,11 @@ class JasmineReporter {
     emit (event, payload) {
         let message = {
             cid: this._cid,
+            uid: this.getUniqueIdentifier(payload),
             event: event,
             title: payload.description,
             pending: payload.status === 'pending',
-            parent: this._parent.length ? this._parent[this._parent.length - 1] : null,
+            parent: this._parent.length ? this.getUniqueIdentifier(this._parent[this._parent.length - 1]) : null,
             type: payload.type,
             file: '',
             err: payload.failedExpectations && payload.failedExpectations.length ? payload.failedExpectations[0] : null,
@@ -74,6 +79,10 @@ class JasmineReporter {
 
     getFailedCount () {
         return this._failedCount
+    }
+
+    getUniqueIdentifier (target) {
+        return target.description + target.id
     }
 }
 

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -16,56 +16,69 @@ describe('jasmine reporter', () => {
     describe('emits messages for certain jasmine events', () => {
         it('should emit suite:start', () => {
             reporter.suiteStarted({
-                description: 'my suite'
+                description: 'my suite',
+                id: 1
             })
             send.calledWithMatch({
                 event: 'suite:start',
-                type: 'suite'
+                type: 'suite',
+                uid: 'my suite1'
             }).should.be.true()
         })
 
         it('should emit spec:start', () => {
-            reporter.specStarted()
+            reporter.specStarted({
+                description: 'my test',
+                id: 2
+            })
             send.calledWithMatch({
                 event: 'test:start',
                 type: 'test',
-                parent: 'my suite'
+                parent: 'my suite1',
+                uid: 'my test2'
             }).should.be.true()
         })
 
         it('should emit spec:done with failed test', () => {
             reporter.specDone({
-                status: 'failed'
+                status: 'failed',
+                description: 'my test',
+                id: 3
             })
             send.calledWithMatch({
                 event: 'test:fail',
                 type: 'test',
-                parent: 'my suite'
+                parent: 'my suite1',
+                uid: 'my test3'
             }).should.be.true()
         })
 
         it('should emit spec:done with passed test', () => {
             reporter.specStarted()
             reporter.specDone({
-                status: 'passed'
+                status: 'passed',
+                description: 'my test',
+                id: 4
             })
             send.calledWithMatch({
                 event: 'test:pass',
                 type: 'test',
-                parent: 'my suite'
+                parent: 'my suite1',
+                uid: 'my test4'
             }).should.be.true()
         })
 
         it('should nest tests in suites', () => {
             reporter.suiteStarted({
-                description: 'does something'
+                description: 'does something',
+                id: 1
             })
             reporter.specStarted()
             reporter.specDone({
                 status: 'failed'
             })
             send.calledWithMatch({
-                parent: 'does something'
+                parent: 'does something1'
             }).should.be.true()
         })
 
@@ -74,7 +87,7 @@ describe('jasmine reporter', () => {
             send.calledWithMatch({
                 event: 'suite:end',
                 type: 'suite',
-                parent: 'my suite'
+                parent: 'my suite1'
             }).should.be.true()
 
             reporter.suiteDone()


### PR DESCRIPTION
**Please note:** this PR is required for fixing issue [#11 reported in the wdio-spec-reporter](https://github.com/webdriverio/wdio-spec-reporter/issues/11) repo, please refer to that issue for more details.

In order to identify each suite & spec when reporting back to the user I added a UID, which is composed from the name of the suite/spec and it's ID. This is also done for any parent suite/spec so we can always use the UID to identify parents as well.

This **is** a breaking change! Since the parent will no longer be correctly reported back to the reporter class. (will now read the UID of the parent)