### PR TITLE
Allow pending reason

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -27,7 +27,7 @@ class JasmineReporter {
          */
         if (Array.isArray(test.failedExpectations)) {
             test.failedExpectations.forEach((e) => {
-                if (e.message === 'Failed: => marked Pending') {
+                if (e.message.includes('Failed: => marked Pending')) {
                     test.status = 'pending'
                     test.failedExpectations = []
                 }

--- a/test/fixtures/tests.xit.spec.js
+++ b/test/fixtures/tests.xit.spec.js
@@ -3,6 +3,11 @@ describe('sample test', () => {
 
     it('can be declared with "it" but without a function and pend').pend('ignore me')
 
+    it('should pend with a reason', () => {
+        pending('ignore reason')
+        throw new Error('ignore me')
+    })
+
     xit('xit', () => {
         throw new Error('ignore me')
     }, 'ignore me')


### PR DESCRIPTION
* This PR fixes a bug where adding a pending reason when calling `pending('reason here')` from within an `it()` caused the test to fail.
* Added a unit test to cover this scenario

If the pending reason isn't available to reporters, we should probably figure out a way to make it available. This is just a quick fix.

cc. @christian-bromann 