### PR TITLE
Fix 'hook exceptions', 'retry flaky (a)sync' Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# IDEs
+.idea

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -61,6 +61,7 @@ class JasmineReporter {
         this._parent.pop()
         suite.type = 'suite'
         suite.duration = new Date() - this._suiteStart
+        this._failedCount += suite.status === 'failed' ? 1 : 0
         this.emit('suite:end', suite)
     }
 

--- a/test/fixtures/tests.retry.async.spec.js
+++ b/test/fixtures/tests.retry.async.spec.js
@@ -1,7 +1,6 @@
 describe('dummy test', () => {
-    let retryCnt
-
     describe('run flaky beforeEach hooks', () => {
+        let retryCnt = 0
         beforeEach(() => {
             retryCnt = 2
         })
@@ -44,6 +43,7 @@ describe('dummy test', () => {
     })
 
     describe('run flaky test', () => {
+        let retryCnt = 0
         before(() => {
             retryCnt = 1
         })
@@ -63,6 +63,7 @@ describe('dummy test', () => {
     })
 
     describe('run flaky test', () => {
+        let retryCnt = 0
         before(() => {
             retryCnt = 3
         })
@@ -82,6 +83,7 @@ describe('dummy test', () => {
     })
 
     describe('run flaky test', () => {
+        let retryCnt = 0
         before(() => {
             retryCnt = 2
         })
@@ -99,6 +101,7 @@ describe('dummy test', () => {
     })
 
     describe('run flaky afterEach hooks', () => {
+        let retryCnt = 0
         afterEach(() => {
             retryCnt = 2
         })

--- a/test/fixtures/tests.retry.async.spec.js
+++ b/test/fixtures/tests.retry.async.spec.js
@@ -1,42 +1,6 @@
 describe('dummy test', () => {
     let retryCnt
 
-    describe('run flaky beforeAll hooks', () => {
-        beforeAll(() => {
-            retryCnt = 2
-        })
-
-        beforeAll(() => {
-            if (retryCnt !== 0) {
-                return browser.command().then((result) => {
-                    retryCnt--
-                    result.should.be.not.equal('foo')
-                })
-            }
-
-            return browser.command().then((result) => {
-                result.should.be.equal('foo')
-            })
-        }, 2)
-
-        beforeAll(() => {
-            retryCnt = 2
-        })
-
-        beforeAll(() => {
-            if (retryCnt !== 0) {
-                retryCnt--
-                throw new Error('FLAKE!')
-            }
-
-            return browser.command().then((result) => {
-                result.should.be.equal('foo')
-            })
-        }, 2)
-
-        it('doesn\'t matter', () => {})
-    })
-
     describe('run flaky beforeEach hooks', () => {
         beforeEach(() => {
             retryCnt = 2
@@ -132,42 +96,6 @@ describe('dummy test', () => {
                 result.should.be.equal('foo')
             })
         }, 2)
-    })
-
-    describe('run flaky afterAll hooks', () => {
-        afterAll(() => {
-            retryCnt = 2
-        })
-
-        afterAll(() => {
-            if (retryCnt !== 0) {
-                return browser.command().then((result) => {
-                    retryCnt--
-                    result.should.be.not.equal('foo')
-                })
-            }
-
-            return browser.command().then((result) => {
-                result.should.be.equal('foo')
-            })
-        }, 2)
-
-        afterAll(() => {
-            retryCnt = 2
-        })
-
-        afterAll(() => {
-            if (retryCnt !== 0) {
-                retryCnt--
-                throw new Error('FLAKE!')
-            }
-
-            return browser.command().then((result) => {
-                result.should.be.equal('foo')
-            })
-        }, 2)
-
-        it('doesn\'t matter', () => {})
     })
 
     describe('run flaky afterEach hooks', () => {

--- a/test/fixtures/tests.retry.sync.spec.js
+++ b/test/fixtures/tests.retry.sync.spec.js
@@ -1,22 +1,6 @@
 describe('sample test', () => {
     let retryCnt
 
-    describe('run flaky beforeAll hooks', () => {
-        beforeAll(() => {
-            retryCnt = 2
-        })
-
-        beforeAll(() => {
-            if (retryCnt-- !== 0) {
-                throw new Error('flaky hook failed')
-            }
-
-            browser.command().should.be.equal('foo')
-        }, 2)
-
-        it('doesn\'t matter', () => {})
-    })
-
     describe('run flaky beforeEach hooks', () => {
         beforeEach(() => {
             retryCnt = 2
@@ -81,19 +65,4 @@ describe('sample test', () => {
         it('doesn\'t matter', () => {})
     })
 
-    describe('run flaky afterAll hooks', () => {
-        afterAll(() => {
-            retryCnt = 2
-        })
-
-        afterAll(() => {
-            if (retryCnt-- !== 0) {
-                throw new Error('flaky hook failed')
-            }
-
-            browser.command().should.be.equal('foo')
-        }, 2)
-
-        it('doesn\'t matter', () => {})
-    })
 })

--- a/test/fixtures/tests.retry.sync.spec.js
+++ b/test/fixtures/tests.retry.sync.spec.js
@@ -64,5 +64,4 @@ describe('sample test', () => {
 
         it('doesn\'t matter', () => {})
     })
-
 })

--- a/test/retry.spec.js
+++ b/test/retry.spec.js
@@ -25,13 +25,15 @@ describe('JasmineAdapter', () => {
         global.browser = new WebdriverIO()
         global.browser.options = {}
         const adapter = new JasmineAdapter(0, JASMINE_NODE_OPTS, syncSpecs, {});
-        (await adapter.run()).should.be.equal(0, 'actual test failed')
+        const result = await adapter.run()
+        result.should.be.equal(0, 'actual test failed')
     })
 
     it('should be able to retry flaky async tests', async () => {
         global.browser = new WebdriverIO()
         global.browser.options = { sync: false }
         const adapter = new JasmineAdapter(0, JASMINE_NODE_OPTS, asyncSpecs, {});
-        (await adapter.run()).should.be.equal(0, 'actual test failed')
+        const result = await adapter.run()
+        result.should.be.equal(0, 'actual test failed')
     })
 })

--- a/test/retry.spec.js
+++ b/test/retry.spec.js
@@ -24,7 +24,7 @@ describe('JasmineAdapter', () => {
     it('should be able to retry flaky sync tests', async () => {
         global.browser = new WebdriverIO()
         global.browser.options = {}
-        const adapter = new JasmineAdapter(0, JASMINE_NODE_OPTS, syncSpecs, {});
+        const adapter = new JasmineAdapter(0, JASMINE_NODE_OPTS, syncSpecs, {})
         const result = await adapter.run()
         result.should.be.equal(0, 'actual test failed')
     })
@@ -32,7 +32,7 @@ describe('JasmineAdapter', () => {
     it('should be able to retry flaky async tests', async () => {
         global.browser = new WebdriverIO()
         global.browser.options = { sync: false }
-        const adapter = new JasmineAdapter(0, JASMINE_NODE_OPTS, asyncSpecs, {});
+        const adapter = new JasmineAdapter(0, JASMINE_NODE_OPTS, asyncSpecs, {})
         const result = await adapter.run()
         result.should.be.equal(0, 'actual test failed')
     })


### PR DESCRIPTION
`failedExpectations` for beforeAll and afterAll are added to the
suite not the spec in jasmine 3.0.0

see https://github.com/jasmine/jasmine/issues/1409#issuecomment-360858185

So I _think_ we could remove the tests which relied on jasmine not failing when exceptions were thrown in beforeAll and afterAll hooks?

Let me know if this make sense..