### PR TITLE
add a ‘passed’ property to the event sent to the afterTest hook.

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -201,6 +201,7 @@ class JasmineAdapter {
 
             if (params.type === 'afterTest') {
                 message.duration = new Date().getTime() - params.payload.start
+                message.passed = params.payload.failedExpectations.length === 0
             }
 
             if (typeof params.payload.duration === 'number') {


### PR DESCRIPTION
Adds a flag to the afterTest event. This is useful for taking screenshots with meaningful filenames after a test failure. example in wdio.conf.js:

```javascript
// Function to be executed after a test (in Mocha/Jasmine) or a step (in Cucumber) starts.
  afterTest: function(test) {
    console.log('afterTest', test.passed);
    // take a screenshot when a test fails
    if (!test.passed) {
      // generate a nice file name
      const fileName = test.fullName .split(' ').join('_');
      browser.saveScreenshot(`${screenshotPath}${fileName}.png`);
    }
  },
```